### PR TITLE
prettyprompt: add switch for dashes

### DIFF
--- a/pkg/prompt/main.go
+++ b/pkg/prompt/main.go
@@ -49,23 +49,25 @@ func Exec(args []string) int {
 	line := strings.Join(fields, " ")
 	lineWidth := getPrintableLength(line)
 
-	//add dashes to expand `line` to fill the terminal's width
-	termWidth, _, err := terminal.GetSize(0)
-	if err != nil {
-		termWidth = 80
-	}
-	if termWidth > lineWidth {
-		line += " "
-		lineWidth++
-	}
-	if termWidth > lineWidth {
-		dashes := make([]byte, termWidth-lineWidth)
-		for idx := range dashes {
-			dashes[idx] = '-'
+	// displayDashes := os.Getenv("PRETTYPROMPT_DASHES")
+	if os.Getenv("PRETTYPROMPT_DASHES") != "false" {
+		//add dashes to expand `line` to fill the terminal's width
+		termWidth, _, err := terminal.GetSize(0)
+		if err != nil {
+			termWidth = 80
 		}
-		line += withColor("1", string(dashes))
+		if termWidth > lineWidth {
+			line += " "
+			lineWidth++
+		}
+		if termWidth > lineWidth {
+			dashes := make([]byte, termWidth-lineWidth)
+			for idx := range dashes {
+				dashes[idx] = '-'
+			}
+			line += withColor("1", string(dashes))
+		}
 	}
-
 	os.Stdout.Write([]byte(line + "\n"))
 
 	//print second line: a letter identifying the shell, and the final "$ ")


### PR DESCRIPTION
This commit would allow people (me) to switch off the dashes on the prompt line that fill up the width of the terminal.

Basically, I won't have to use my forked version but rather use the upstream and stay on the latest commit 😄 