### PR TITLE
Always append .git when searching to better support copied URLs from GitHub UI

### DIFF
--- a/internal/rtree/index.go
+++ b/internal/rtree/index.go
@@ -226,7 +226,8 @@ func (i *Index) FindRepo(rawRemoteURL string, allowClone bool) (*Repo, error) {
 	for _, repo := range i.Repos {
 		isCandidate := false
 		for _, remote := range repo.Remotes {
-			if remoteURL == remote.URL {
+			// be flexible about .git ending in remote
+			if remoteURL == remote.URL || remoteURL+".git" == remote.URL || remoteURL == remote.URL+".git" {
 				return repo, nil
 			}
 			if basename == path.Base(remote.URL.CanonicalURL()) {

--- a/internal/rtree/index.go
+++ b/internal/rtree/index.go
@@ -128,8 +128,7 @@ func (i *Index) Rebuild() error {
 	//check if existing index entries are still checked out
 	var newRepos []*Repo
 	for _, repo := range i.Repos {
-		gitDirPath := filepath.Join(repo.AbsolutePath(), ".git")
-		fi, err := os.Stat(gitDirPath)
+		fi, err := os.Stat(repo.GitDirPath())
 		switch {
 		case err == nil:
 			// in a normal repo .git is a directory but when the repo is a submodule of another repo
@@ -139,7 +138,7 @@ func (i *Index) Rebuild() error {
 				newRepos = append(newRepos, repo)
 				continue
 			}
-			return fmt.Errorf("expected repository at %s, but is not a directory or file", gitDirPath)
+			return fmt.Errorf("expected repository at %s, but is not a directory or file", repo.GitDirPath())
 		case !os.IsNotExist(err):
 			return err
 		}

--- a/internal/rtree/repo.go
+++ b/internal/rtree/repo.go
@@ -49,6 +49,11 @@ func (r Repo) AbsolutePath() string {
 	return filepath.Join(RootPath, r.CheckoutPath)
 }
 
+//GitDirPath returns the path of the .git directory of this repo.
+func (r Repo) GitDirPath() string {
+	return filepath.Join(r.AbsolutePath(), ".git")
+}
+
 //NewRepoFromAbsolutePath initializes a Repo instance by scanning the existing
 //checkout at the given path.
 func NewRepoFromAbsolutePath(path string) (repo Repo, err error) {


### PR DESCRIPTION
before:

```ShellSession
$ gofu rtree get https://github.com/sapcc/helm-charts
!! /home/sandro/src/github.com/sapcc/helm-charts already exists (if there is a repo there, try `rtree index`)
```

with this change:

```ShellSession
$ ./gofu rtree get https://github.com/sapcc/helm-charts
/home/sandro/src/github.com/sapcc/helm-charts
```


``git remote -v`` output of the repo

```ShellSession
$ git remote -v
origin  https://github.com/sapcc/helm-charts.git (fetch)
origin  git@github.com:sapcc/helm-charts.git (push
```